### PR TITLE
Defining process count interval alarm

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,5 @@ notification_address: root@localhost
 notification_name: 'Default Email'
 notification_type: EMAIL
 keystone_project:
+process_count_lower_bound: 1
+process_count_upper_bound: 32

--- a/tasks/system.yml
+++ b/tasks/system.yml
@@ -26,3 +26,7 @@
         severity: "HIGH",
         expression: "process.pid_count < 1",
         match_by: ["process_name", "hostname"] }
+    - { name: "Process count interval",
+        description: "Check if the number of processes are included in a specific interval",
+        severity: "HIGH",
+        expression: "process.pid_count >= {{process_count_lower_bound}} and process.pid_count <= {{process_count_lower_bound}}" }

--- a/tasks/system.yml
+++ b/tasks/system.yml
@@ -29,4 +29,4 @@
     - { name: "Process count interval",
         description: "Check if the number of processes are included in a specific interval",
         severity: "HIGH",
-        expression: "process.pid_count >= {{process_count_lower_bound}} and process.pid_count <= {{process_count_lower_bound}}" }
+        expression: "process.pid_count >= {{process_count_lower_bound}} and process.pid_count <= {{process_count_upper_bound}}" }


### PR DESCRIPTION
This change is to create a new alarm definition which triggers the alarm
if the number of processes is not included into a specific range defined
by default as 1-32.
Some services need to have more than one processes to run on the same
box at the same time but the number of them must not exceed a specific
bound, this new alarm can monitor this scenario.
