### PR TITLE
Allow activate_this.py to be a symbolic link

### DIFF
--- a/library/monasca_alarm_definition.py
+++ b/library/monasca_alarm_definition.py
@@ -108,13 +108,14 @@ EXAMPLES = '''
 '''
 
 from ansible.module_utils.basic import *
+import os
 
 try:
     from monascaclient import client
     from monascaclient import ksclient
 except ImportError:
     # In many installs the python-monascaclient is available in a venv, switch to the most common location
-    activate_this = '/opt/monasca/bin/activate_this.py'
+    activate_this = os.path.realpath('/opt/monasca/bin/activate_this.py')
     try:
         execfile(activate_this, dict(__file__=activate_this))
         from monascaclient import client

--- a/library/monasca_notification_method.py
+++ b/library/monasca_notification_method.py
@@ -87,13 +87,14 @@ EXAMPLES = '''
 '''
 
 from ansible.module_utils.basic import *
+import os
 
 try:
     from monascaclient import client
     from monascaclient import ksclient
 except ImportError:
     # In many installs the python-monascaclient is available in a venv, switch to the most common location
-    activate_this = '/opt/monasca/bin/activate_this.py'
+    activate_this = os.path.realpath('/opt/monasca/bin/activate_this.py')
     try:
         execfile(activate_this, dict(__file__=activate_this))
         from monascaclient import client


### PR DESCRIPTION
Resolve the absolute path to activate_this.py before using it
